### PR TITLE
MDMA + Amphetamine update

### DIFF
--- a/combos.json
+++ b/combos.json
@@ -444,8 +444,8 @@
       "status": "Dangerous"
     },
     "mdma": {
-      "note": "Amphetamines increase the neurotoxic effects of MDMA",
-      "status": "Low Risk & Synergy"
+      "note": "This combination of stimulants will increase strain on the heart, may cause some physical discomfort, and has the chance to cause cardiovascular issues. The anxiogenic and focusing effects of stimulants can increase the chance of unpleasant thought loops and make the experience more uncomfortable, this combination raises these chances. Amphetamines will increase the neurotoxic effects of MDMA, in addition to causing further concerns of hyperthermia due to the inherent nature of the combination. It will also raise one's body tempature, also likely making the combination more neurotoxic.",
+      "status": "Caution"
     },
     "mescaline": {
       "note": "The focus and anxiety caused by stimulants is magnified by psychedelics and results in an increased risk of thought loops",

--- a/combos.json
+++ b/combos.json
@@ -444,7 +444,7 @@
       "status": "Dangerous"
     },
     "mdma": {
-      "note": "This combination of stimulants will increase strain on the heart, may cause some physical discomfort, and has the chance to cause cardiovascular issues. The anxiogenic and focusing effects of stimulants can increase the chance of unpleasant thought loops and make the experience more uncomfortable, this combination raises these chances. Amphetamines will increase the neurotoxic effects of MDMA, in addition to causing further concerns of hyperthermia due to the inherent nature of the combination. It will also raise one's body tempature, also likely making the combination more neurotoxic.",
+      "note": "This combination of stimulants will increase strain on the heart, may cause some physical discomfort, and has the chance to cause cardiovascular issues. The anxiogenic and focusing effects of stimulants can increase the chance of unpleasant thought loops and make the experience more uncomfortable, this combination raises these chances. Amphetamines will increase the neurotoxic effects of MDMA, in addition to causing further concerns of hyperthermia due to the inherent nature of the combination. It will also raise one's body temperature, also likely making the combination more neurotoxic.",
       "status": "Caution"
     },
     "mescaline": {

--- a/combos.json
+++ b/combos.json
@@ -445,6 +445,11 @@
     },
     "mdma": {
       "note": "This combination of stimulants will increase strain on the heart, may cause some physical discomfort, and has the chance to cause cardiovascular issues. The anxiogenic and focusing effects of stimulants can increase the chance of unpleasant thought loops and make the experience more uncomfortable, this combination raises these chances. Amphetamines will increase the neurotoxic effects of MDMA, in addition to causing further concerns of hyperthermia due to the inherent nature of the combination. It will also raise one's body temperature, also likely making the combination more neurotoxic.",
+      "sources": [
+        "https://onlinelibrary.wiley.com/doi/abs/10.1080/09595230601036945",
+        "https://pubmed.ncbi.nlm.nih.gov/16884865/",
+        "https://onlinelibrary.wiley.com/doi/10.1111/j.0953-816X.2004.03453.x"
+      ],
       "status": "Caution"
     },
     "mescaline": {
@@ -1628,8 +1633,13 @@
       "status": "Caution"
     },
     "amphetamines": {
-      "note": "Amphetamines increase the neurotoxic effects of MDMA",
-      "status": "Low Risk & Synergy"
+      "note": "This combination of stimulants will increase strain on the heart, may cause some physical discomfort, and has the chance to cause cardiovascular issues. The anxiogenic and focusing effects of stimulants can increase the chance of unpleasant thought loops and make the experience more uncomfortable, this combination raises these chances. Amphetamines will increase the neurotoxic effects of MDMA, in addition to causing further concerns of hyperthermia due to the inherent nature of the combination. It will also raise one's body temperature, also likely making the combination more neurotoxic.",
+      "sources": [
+        "https://onlinelibrary.wiley.com/doi/abs/10.1080/09595230601036945",
+        "https://pubmed.ncbi.nlm.nih.gov/16884865/",
+        "https://onlinelibrary.wiley.com/doi/10.1111/j.0953-816X.2004.03453.x"
+      ],
+      "status": "Caution"
     },
     "amt": {
       "status": "Dangerous"

--- a/drugs.json
+++ b/drugs.json
@@ -24032,8 +24032,13 @@
         "status": "Caution"
       },
       "amphetamines": {
-        "note": "Amphetamines increase the neurotoxic effects of MDMA",
-        "status": "Low Risk & Synergy"
+        "note": "This combination of stimulants will increase strain on the heart, may cause some physical discomfort, and has the chance to cause cardiovascular issues. The anxiogenic and focusing effects of stimulants can increase the chance of unpleasant thought loops and make the experience more uncomfortable, this combination raises these chances. Amphetamines will increase the neurotoxic effects of MDMA, in addition to causing further concerns of hyperthermia due to the inherent nature of the combination. It will also raise one's body temperature, also likely making the combination more neurotoxic.",
+        "sources": [
+          "https://onlinelibrary.wiley.com/doi/abs/10.1080/09595230601036945",
+          "https://pubmed.ncbi.nlm.nih.gov/16884865/",
+          "https://onlinelibrary.wiley.com/doi/10.1111/j.0953-816X.2004.03453.x"
+        ],
+        "status": "Caution"
       },
       "amt": {
         "status": "Dangerous"

--- a/schemas/combos-schema.json
+++ b/schemas/combos-schema.json
@@ -245,6 +245,9 @@
                 },
                 "note": {
                     "type": "string"
+                },
+                "sources": {
+                    "type": "array"
                 }
             },
             "required": [

--- a/schemas/drugs-schema.json
+++ b/schemas/drugs-schema.json
@@ -481,6 +481,9 @@
               "note": {
                   "type": "string"
               },
+              "sources": {
+                "type": "array"
+              },
               "status": {
                   "$ref": "#/definitions/Status"
               }

--- a/types/combos.d.ts
+++ b/types/combos.d.ts
@@ -59,8 +59,9 @@ export interface Interactions {
 }
 
 export interface ComboData {
+  note?: string;
+  sources?: string[];
   status: Status;
-  note?:   string;
 }
 
 export enum Status {

--- a/types/drugs.d.ts
+++ b/types/drugs.d.ts
@@ -143,6 +143,7 @@ export type Properties = {
 
 export type Combo = {
   note?: string;
+  sources?: string[];
   status: Status;
 };
 


### PR DESCRIPTION
Suggested interaction change: MDMA + Amphetamines

"This combination of stimulants will increase strain on the heart, may cause some physical discomfort, and has the chance to cause cardiovascular issues. The anxiogenic and focusing effects of stimulants can increase the chance of unpleasant thought loops and make the experience more uncomfortable, this combination raises these chances. Amphetamines will increase the neurotoxic effects of MDMA, in addition to causing further concerns of hyperthermia due to the inherent nature of the combination. It will also raise one's body temperature, also likely making the combination more neurotoxic."
Change to: Caution

As discussed in the combo chart discord channel, this interaction is recommended to change to caution. As noted in the edit, the combination will increase strain on the heart and other various cardiovascular issues, such as increased blood pressure. The combination will raise one's body temperature, in which this would make the MDMA more neurotoxic. As stated in the original interaction, amphetamine's will increase MDMA's neurotoxicity.

Relevant studies-
https://onlinelibrary.wiley.com/doi/abs/10.1080/09595230601036945
https://pubmed.ncbi.nlm.nih.gov/16884865/
https://onlinelibrary.wiley.com/doi/10.1111/j.0953-816X.2004.03453.x

Discord conversation archive-
https://hastebin.skyra.pw/cuyufonodi.rust