### PR TITLE
Update drugs-schema to include known combo names

### DIFF
--- a/drugs.json
+++ b/drugs.json
@@ -10967,10 +10967,6 @@
         "note": "Ethanol ingestion may potentiate the CNS effects of many benzodiazepines. The two substances potentiate each other strongly and unpredictably, very rapidly leading to unconsciousness. While unconscious, vomit aspiration is a risk if not placed in the recovery position. Blacking out and memory loss is almost certain.",
         "status": "Dangerous"
       },
-      "benzos": {
-        "note": "Ethanol ingestion may potentiate the CNS effects of many benzodiazepines. The two substances potentiate each other strongly and unpredictably, very rapidly leading to unconsciousness. While unconscious, vomit aspiration is a risk if not placed in the recovery position. Blacking out and memory loss is almost certain.",
-        "status": "Dangerous"
-      },
       "caffeine": {
         "status": "Low Risk & No Synergy"
       },
@@ -12081,9 +12077,6 @@
         "status": "Dangerous"
       },
       "benzodiazepines": {
-        "status": "Low Risk & Decrease"
-      },
-      "benzos": {
         "status": "Low Risk & Decrease"
       },
       "caffeine": {
@@ -13807,9 +13800,6 @@
       "benzodiazepines": {
         "status": "Low Risk & Decrease"
       },
-      "benzos": {
-        "status": "Low Risk & Decrease"
-      },
       "cannabis": {
         "status": "Low Risk & No Synergy"
       },
@@ -14065,9 +14055,6 @@
         "status": "Caution"
       },
       "benzodiazepines": {
-        "status": "Low Risk & Decrease"
-      },
-      "benzos": {
         "status": "Low Risk & Decrease"
       },
       "caffeine": {
@@ -15249,9 +15236,6 @@
         "status": "Dangerous"
       },
       "benzodiazepines": {
-        "status": "Low Risk & Decrease"
-      },
-      "benzos": {
         "status": "Low Risk & Decrease"
       },
       "caffeine": {
@@ -16724,10 +16708,6 @@
         "note": "Small doses of benzos can end a bad trip, but both substances potentiate the ataxia and sedation caused by the other and this can lead to unexpected loss of consciousness at high doses. While unconscious, vomit aspiration is a risk if not placed in the recovery position.",
         "status": "Caution"
       },
-      "benzos": {
-        "note": "Small doses of benzos can end a bad trip, but both substances potentiate the ataxia and sedation caused by the other and this can lead to unexpected loss of consciousness at high doses. While unconscious, vomit aspiration is a risk if not placed in the recovery position.",
-        "status": "Caution"
-      },
       "caffeine": {
         "note": "High doses of caffeine can potentially exacerbate anxiety, especially during a dissociative experience, due to its stimulating effects. This combination might also lead to physical discomfort. However, individual responses to caffeine can vary significantly, often influenced by factors like habitual versus occasional usage.",
         "sources": [
@@ -17877,9 +17857,6 @@
         "status": "Low Risk & Synergy"
       },
       "benzodiazepines": {
-        "status": "Low Risk & Decrease"
-      },
-      "benzos": {
         "status": "Low Risk & Decrease"
       },
       "caffeine": {
@@ -22650,10 +22627,6 @@
         "note": "Both substances potentiate the ataxia and sedation caused by the other and can lead to unexpected loss of consciousness at high doses. While unconscious, vomit aspiration is a risk if not placed in the recovery position.",
         "status": "Caution"
       },
-      "benzos": {
-        "note": "Both substances potentiate the ataxia and sedation caused by the other and can lead to unexpected loss of consciousness at high doses. While unconscious, vomit aspiration is a risk if not placed in the recovery position.",
-        "status": "Caution"
-      },
       "caffeine": {
         "note": "No unexpected interactions.",
         "status": "Low Risk & No Synergy"
@@ -23876,9 +23849,6 @@
       "benzodiazepines": {
         "status": "Low Risk & Decrease"
       },
-      "benzos": {
-        "status": "Low Risk & Decrease"
-      },
       "caffeine": {
         "status": "Low Risk & No Synergy"
       },
@@ -24607,9 +24577,6 @@
         "status": "Dangerous"
       },
       "benzodiazepines": {
-        "status": "Low Risk & Decrease"
-      },
-      "benzos": {
         "status": "Low Risk & Decrease"
       },
       "caffeine": {
@@ -25414,7 +25381,7 @@
       "empathogen"
     ],
     "combos": {
-      "dxm": {
+      "dextromethorphan": {
         "note": "Risk of serotonin syndrome as both drugs raise serotonin levels. In addition to concerns of high blood pressure and unnecessary strain on the heart. As well as potentially causing anxiety and greater physical discomfort due to the combination.",
         "sources": [
           {
@@ -25664,9 +25631,6 @@
         "status": "Dangerous"
       },
       "benzodiazepines": {
-        "status": "Low Risk & Decrease"
-      },
-      "benzos": {
         "status": "Low Risk & Decrease"
       },
       "caffeine": {
@@ -27913,9 +27877,6 @@
       "benzodiazepines": {
         "status": "Low Risk & Decrease"
       },
-      "benzos": {
-        "status": "Low Risk & Decrease"
-      },
       "caffeine": {
         "status": "Low Risk & No Synergy"
       },
@@ -28151,10 +28112,6 @@
       },
       "benzodiazepines": {
         "note": "Both substances potentiate the ataxia and sedation caused by the other and can lead to unexpected loss of consciousness at high doses. Place the affected individual in the recovery position to prevent vomit aspiration from excess.",
-        "status": "Caution"
-      },
-      "benzos": {
-        "note": "Both substances potentiate the ataxia and sedation caused by the other and can lead to unexpected loss of consciousness at high doses. place the affected individual in the recovery position to prevent vomit aspiration from excess.",
         "status": "Caution"
       },
       "caffeine": {
@@ -29055,9 +29012,6 @@
         "status": "Low Risk & Synergy"
       },
       "benzodiazepines": {
-        "status": "Low Risk & Decrease"
-      },
-      "benzos": {
         "status": "Low Risk & Decrease"
       },
       "caffeine": {
@@ -30262,10 +30216,6 @@
         "status": "Dangerous"
       },
       "benzodiazepines": {
-        "note": "Both substances potentiate the ataxia and sedation caused by the other and can lead to unexpected loss of consciousness at high doses. While unconscious, vomit aspiration is a risk if not placed in the recovery position. Memory blackouts are likely",
-        "status": "Unsafe"
-      },
-      "benzos": {
         "note": "Both substances potentiate the ataxia and sedation caused by the other and can lead to unexpected loss of consciousness at high doses. While unconscious, vomit aspiration is a risk if not placed in the recovery position. Memory blackouts are likely",
         "status": "Unsafe"
       },
@@ -33937,10 +33887,6 @@
       },
       "benzodiazepines": {
         "note": "Central nervous system- and/or respiratory-depressant effects may be additively or synergistically present. Vomit aspiration is a risk when passed out, lay down in recovery position if ingested.",
-        "status": "Dangerous"
-      },
-      "benzos": {
-        "note": "Central nervous system- and/or respiratory-depressant effects may be additively or synergistically present. Vomit aspiration a risk when passed out, lay down in recovery position if ingested.",
         "status": "Dangerous"
       },
       "caffeine": {

--- a/schemas/drugs-schema.json
+++ b/schemas/drugs-schema.json
@@ -69,9 +69,39 @@
               },
               "combos": {
                   "type": "object",
-                  "additionalProperties": {
-                      "$ref": "#/definitions/Combo"
-                  }
+                  "properties": {
+                    "2c-t-x": { "$ref": "#/definitions/Combo" },
+                    "2c-x": { "$ref": "#/definitions/Combo" },
+                    "5-meo-xxt": { "$ref": "#/definitions/Combo" },
+                    "alcohol": { "$ref": "#/definitions/Combo" },
+                    "amphetamines": { "$ref": "#/definitions/Combo" },
+                    "amt": { "$ref": "#/definitions/Combo" },
+                    "benzodiazepines": { "$ref": "#/definitions/Combo" },
+                    "caffeine": { "$ref": "#/definitions/Combo" },
+                    "cannabis": { "$ref": "#/definitions/Combo" },
+                    "cocaine": { "$ref": "#/definitions/Combo" },
+                    "dextromethorphan": { "$ref": "#/definitions/Combo" },
+                    "diphenhydramine": { "$ref": "#/definitions/Combo" },
+                    "dmt": { "$ref": "#/definitions/Combo" },
+                    "dox": { "$ref": "#/definitions/Combo" },
+                    "ghb/gbl": { "$ref": "#/definitions/Combo" },
+                    "lithium": { "$ref": "#/definitions/Combo" },
+                    "ketamine": { "$ref": "#/definitions/Combo" },
+                    "lsd": { "$ref": "#/definitions/Combo" },
+                    "maois": { "$ref": "#/definitions/Combo" },
+                    "mdma": { "$ref": "#/definitions/Combo" },
+                    "mephedrone": { "$ref": "#/definitions/Combo" },
+                    "mescaline": { "$ref": "#/definitions/Combo" },
+                    "mushrooms": { "$ref": "#/definitions/Combo" },
+                    "mxe": { "$ref": "#/definitions/Combo" },
+                    "nbomes": { "$ref": "#/definitions/Combo" },
+                    "nitrous": { "$ref": "#/definitions/Combo" },
+                    "opioids": { "$ref": "#/definitions/Combo" },
+                    "pcp": { "$ref": "#/definitions/Combo" },
+                    "ssris": { "$ref": "#/definitions/Combo" },
+                    "tramadol": { "$ref": "#/definitions/Combo" }
+                  },
+                  "additionalProperties": false
               }
           },
           "required": [


### PR DESCRIPTION
Nerdifly pointed out that some drugs have combo info for "benzodiazepines" and also "benzos"

It turns out that some drugs.json drugs had both of these values, so i added a section to the drugs-schema file: This file defines how the drugs.json should look, including which Combo names are valid. After doing that, there were errors in JSON that I cleaned up, including renaming the mephedrone > dxm combo to dextromethorphan.

This is an easy approval, just wanted to follow the process and explain.

