### PR TITLE
Update combos.json

### DIFF
--- a/combos.json
+++ b/combos.json
@@ -105,7 +105,7 @@
       "status": "Low Risk & Synergy"
     },
     "opioids": {
-      "note": "No expected interactions, some opioids have serotonin action, and could lead to Serotonin Syndrome or a seizure. These are pretty much only to Pentazocine, Methadone, Tramadol, Tapenatdol.",
+      "note": "There may be a risk with some opioids, namely serotonergic ones.",
       "status": "Low Risk & No Synergy"
     },
     "pcp": {
@@ -3239,7 +3239,7 @@
   },
   "opioids": {
     "2c-t-x": {
-      "note": "No expected interactions, some opioids have serotonin action, and could lead to Serotonin Syndrome or a seizure. These are pretty much only to Pentazocine, Methadone, Tramadol, Tapenatdol.",
+There may be a risk with some opioids, namely serotonergic ones.
       "status": "Low Risk & No Synergy"
     },
     "2c-x": {


### PR DESCRIPTION
This removes "No expected interactions, some opioids have serotonin action, and could lead to Serotonin Syndrome or a seizure. These are pretty much only to Pentazocine, Methadone, Tramadol, Tapenatdol."

While this combination should be reworded and have additional things added to it (this also relates to the discussion of possibly changing from drug groups to specific drugs), this note is potentially harmful. This is more or less a temporary placeholder as it communicates the same message, but doesn't close off possibilities for other opioids possibly causing serotonin syndrome, and doesn't say "no expected interactions"