### PR TITLE
duplicate duration type/field Oral ER

### DIFF
--- a/schemas/drugs-schema.json
+++ b/schemas/drugs-schema.json
@@ -253,7 +253,7 @@
               "Smoked": {
                   "type": "string"
               },
-              "ORAL_ER": {
+              "Oral_ER": {
                   "type": "string"
               },
               "Oral_IR": {
@@ -281,9 +281,6 @@
                   "type": "string"
               },
               "Sublingual": {
-                  "type": "string"
-              },
-              "Oral_ER": {
                   "type": "string"
               },
               "Insufflated_IR": {


### PR DESCRIPTION
fixes inconsistency. ORAL_ER duration field/type removed. not seen used in any entry in drugs.json so no conflicts.