### PR TITLE
Update drug aliases

### DIFF
--- a/drugs.json
+++ b/drugs.json
@@ -21478,7 +21478,15 @@
     "properties": {
       "after-effects": "1-24 hours.",
       "aliases": [
-        "diamorphine"
+        "diamorphine",
+        "smack",
+        "H",
+        "big H",
+        "black tar",
+        "horse",
+        "junk",
+        "thunder",
+        "TNT"
       ],
       "bioavailability": "Oral 35% | Intramuscular 85%",
       "categories": [
@@ -26536,7 +26544,8 @@
     "aliases": [
       "meth",
       "desoxyn",
-      "tik"
+      "tik",
+      "ice"
     ],
     "categories": [
       "stimulant",


### PR DESCRIPTION
Adds heroin aliases:
Heroin. (2023, September 8). Medlineplus.gov; National Library of Medicine. https://medlineplus.gov/heroin.html

Adds "ice" as an alias for methamphetamine:
Better Health Channel. (2012). Ice. Vic.gov.au. https://www.betterhealth.vic.gov.au/health/HealthyLiving/Ice