### PR TITLE
Fixed combos.json formatting

### DIFF
--- a/combos.json
+++ b/combos.json
@@ -2963,6 +2963,7 @@
       "status": "Dangerous"
     }
   },
+  },
   "mescaline": {
     "2c-t-x": {
       "status": "Caution"


### PR DESCRIPTION
Added a bracket and a comma to fix a formatting issue in mephedrone -> lsd that caused a bunch of other sections to be in the wrong place within the json object