### PR TITLE
fix: combos.json formatting

### DIFF
--- a/combos.json
+++ b/combos.json
@@ -2916,6 +2916,7 @@
         }
       ],
       "status": "Caution"
+    },
     "mdma": {
       "note": "Risk of serotonin syndrome as both drugs raise serotonin levels. Stimulants also increase the neurotoxic effects of MDMA, in addition to concerns of high blood pressure and unnecessary strain on the heart. As well as potentially causing anxiety and greater physical discomfort due to the combination.",
       "sources": [


### PR DESCRIPTION
Added a bracket and a comma to fix a formatting issue in mephedrone -> lsd that caused a bunch of other sections to be in the wrong place within the json object